### PR TITLE
Document stdlib-only convention for scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ One JSON per note (rather than an aggregate log) makes the corpus trivially inge
 - **Commit anchor required.** The recorder fails if the cwd is not in a git repo with at least one commit. Every note ties to a codebase snapshot.
 - **Recency wins.** When notes conflict, the newer one supersedes. `consult-why-notes` surfaces newest-first to make this obvious.
 - **Skip the obvious.** Don't record what the code already shows or the commit message already explains. Notes are for the *why* that would otherwise be lost.
+- **Standard library only.** Scripts in this repo must not import anything outside the Python standard library. No `pip install`, no `requirements.txt`, no virtualenv — the tools must run on a bare-bones machine with only `python3` and `git` available. Reach for the stdlib (or shell out to `git`) before introducing any third-party dependency.
 
 ## Repository structure
 

--- a/why-notes/why-notes/skills/consult-why-notes/src/skill.py-0066d728-008b-4500-881d-b49e4ee10c4e.json
+++ b/why-notes/why-notes/skills/consult-why-notes/src/skill.py-0066d728-008b-4500-881d-b49e4ee10c4e.json
@@ -1,0 +1,16 @@
+{
+  "timestamp": "2026-05-02T14:20:57.101747+00:00",
+  "uuid": "0066d728-008b-4500-881d-b49e4ee10c4e",
+  "agent": "human",
+  "model": "Joose Rajamäki",
+  "repo": "why-notes",
+  "repo_url": "git@github.com:JooseRajamaeki/why-notes.git",
+  "dir": "skills/consult-why-notes/src",
+  "basename": "skill.py",
+  "branch": "main",
+  "commit": "0498c18",
+  "related": [
+    "cfc2e616-0e41-46dc-90f3-3950bc8ddcd8"
+  ],
+  "note": "We should document for all scripts that we should avoid importing anything that's not in the standard library in order to avoid dependency management and for the whole system to be maximally portably on as bare-bones machine as possible."
+}

--- a/why-notes/why-notes/skills/why-notes/src/skill.py-cfc2e616-0e41-46dc-90f3-3950bc8ddcd8.json
+++ b/why-notes/why-notes/skills/why-notes/src/skill.py-cfc2e616-0e41-46dc-90f3-3950bc8ddcd8.json
@@ -1,0 +1,14 @@
+{
+  "timestamp": "2026-05-02T14:20:33.621068+00:00",
+  "uuid": "cfc2e616-0e41-46dc-90f3-3950bc8ddcd8",
+  "agent": "human",
+  "model": "Joose Rajamäki",
+  "repo": "why-notes",
+  "repo_url": "git@github.com:JooseRajamaeki/why-notes.git",
+  "dir": "skills/why-notes/src",
+  "basename": "skill.py",
+  "branch": "main",
+  "commit": "0498c18",
+  "related": [],
+  "note": "We should document for all scripts that we should avoid importing anything that's not in the standard library in order to avoid dependency management and for the whole system to be maximally portably on as bare-bones machine as possible."
+}


### PR DESCRIPTION
Adds a Conventions bullet in README explaining that scripts in this repo must not import outside Python's stdlib so the tools run on a bare-bones machine with only python3 and git. Records the same rationale as why-notes against both script files (cross-linked via related) so consult-why-notes surfaces it before either is edited.