### PR TITLE
Add bidirectional cross-linking to why-notes

### DIFF
--- a/skills/why-notes/src/skill.py
+++ b/skills/why-notes/src/skill.py
@@ -10,6 +10,28 @@ from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 
 
+def _load_uuid(path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8")).get("uuid")
+    except Exception:
+        return None
+
+
+def _backlink(notes_root, rel_uuid, note_uuid):
+    found = next(
+        (p for p in notes_root.rglob("*.json") if _load_uuid(p) == rel_uuid),
+        None,
+    )
+    if found is None:
+        print(f"why-notes: warning: related uuid {rel_uuid!r} not found; skipping back-link", file=sys.stderr)
+        return
+    rel_record = json.loads(found.read_text(encoding="utf-8"))
+    if note_uuid not in rel_record.get("related", []):
+        rel_record.setdefault("related", []).append(note_uuid)
+        found.write_text(json.dumps(rel_record, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        print(f"why-notes: back-linked {found}", file=sys.stderr)
+
+
 def git(*args, cwd):
     try:
         r = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, timeout=5)
@@ -165,6 +187,10 @@ def main():
     out = notes_dir / filename
     out.write_text(json.dumps(record, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
     print(f"why-notes: wrote {out}", file=sys.stderr)
+
+    for rel_uuid in args.related:
+        _backlink(notes_root, rel_uuid, note_uuid)
+
     return 0
 
 

--- a/why-notes/why-notes/skills/why-notes/src/skill.py-15017160-f608-4682-baa9-0cd174501ee3.json
+++ b/why-notes/why-notes/skills/why-notes/src/skill.py-15017160-f608-4682-baa9-0cd174501ee3.json
@@ -1,0 +1,16 @@
+{
+  "timestamp": "2026-05-02T16:38:35.859480+00:00",
+  "uuid": "15017160-f608-4682-baa9-0cd174501ee3",
+  "agent": "claude",
+  "model": "claude-sonnet-4-6",
+  "repo": "why-notes",
+  "repo_url": "git@github.com:JooseRajamaeki/why-notes.git",
+  "dir": "skills/why-notes/src",
+  "basename": "skill.py",
+  "branch": "main",
+  "commit": "909ba45",
+  "related": [
+    "b7a9d15b-0363-4d04-ba33-d6816f4ee87c"
+  ],
+  "note": "Backward cross-linking was added so that the dependency graph is bidirectionally traversable without needing a separate index. When a new note is created with --related UUIDs, the script immediately patches each referenced note's \"related\" list to include the new note's UUID. The alternative — querying forward links at read time — was rejected because it would require the consumer (consult-why-notes) to do a full scan on every traversal step rather than at write time once. Idempotency guard (skip if UUID already present) prevents duplicates on re-runs."
+}

--- a/why-notes/why-notes/skills/why-notes/src/skill.py-b7a9d15b-0363-4d04-ba33-d6816f4ee87c.json
+++ b/why-notes/why-notes/skills/why-notes/src/skill.py-b7a9d15b-0363-4d04-ba33-d6816f4ee87c.json
@@ -1,0 +1,16 @@
+{
+  "timestamp": "2026-05-02T16:38:59.228180+00:00",
+  "uuid": "b7a9d15b-0363-4d04-ba33-d6816f4ee87c",
+  "agent": "claude",
+  "model": "claude-sonnet-4-6",
+  "repo": "why-notes",
+  "repo_url": "git@github.com:JooseRajamaeki/why-notes.git",
+  "dir": "skills/why-notes/src",
+  "basename": "skill.py",
+  "branch": "main",
+  "commit": "909ba45",
+  "related": [
+    "15017160-f608-4682-baa9-0cd174501ee3"
+  ],
+  "note": "The back-linking logic was extracted into _backlink() (and _load_uuid() as its helper) rather than inlined into main(). main() was already large and the user explicitly rejected an inline patch in favour of a dedicated function. This sets a precedent: new behaviour added to skill.py should live in named helpers rather than growing main() further."
+}


### PR DESCRIPTION
When a new note is created with --related UUIDs, each referenced note
is now patched to include the new note's UUID in its own related list,
so the dependency graph can be traversed in both directions.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)