### PR TITLE
Require one architectural decision per note

### DIFF
--- a/skills/why-notes/SKILL.md
+++ b/skills/why-notes/SKILL.md
@@ -25,8 +25,9 @@ Pass `--related` UUIDs (look them up via `consult.py`) when this decision builds
 
 Run either script with `--help` for the full contract.
 
-Two rules the script can't enforce:
+Three rules the script can't enforce:
 
+- **One decision per note.** Keep each note minimal and focused on a single architectural decision. Splitting one discussion into several notes is encouraged.
 - **Verbatim human input.** When `--agent human`, copy the user's message into the heredoc unchanged — no paraphrasing or reordering.
 - **Human's name as --model.** Ask once at session start what name to use; reuse it for every human entry that session.
 

--- a/why-notes/why-notes/skills/why-notes/SKILL.md-280cef8d-0dce-4b39-94dc-f4a0cf240d25.json
+++ b/why-notes/why-notes/skills/why-notes/SKILL.md-280cef8d-0dce-4b39-94dc-f4a0cf240d25.json
@@ -8,6 +8,8 @@
   "basename": "SKILL.md",
   "branch": "main",
   "commit": "85f2fa6",
-  "related": [],
+  "related": [
+    "d9e2bf0a-c531-4afc-903e-d79d27c2b4f1"
+  ],
   "note": "The skill md file is now way too verbose. The script should guide any agent to relevant practices and take care of the formatting."
 }

--- a/why-notes/why-notes/skills/why-notes/SKILL.md-cc2dd3d5-9e0e-471a-bbd2-a6160d4c7368.json
+++ b/why-notes/why-notes/skills/why-notes/SKILL.md-cc2dd3d5-9e0e-471a-bbd2-a6160d4c7368.json
@@ -8,6 +8,8 @@
   "basename": "SKILL.md",
   "branch": "",
   "commit": "66128bb",
-  "related": [],
+  "related": [
+    "d9e2bf0a-c531-4afc-903e-d79d27c2b4f1"
+  ],
   "note": "Let's also add that any human input related to architecture, such as this, should be recorded to the notes verbatim. No additions or modifications allowed when recording the human input."
 }

--- a/why-notes/why-notes/skills/why-notes/SKILL.md-d9e2bf0a-c531-4afc-903e-d79d27c2b4f1.json
+++ b/why-notes/why-notes/skills/why-notes/SKILL.md-d9e2bf0a-c531-4afc-903e-d79d27c2b4f1.json
@@ -1,0 +1,18 @@
+{
+  "timestamp": "2026-05-02T17:46:15.341072+00:00",
+  "uuid": "d9e2bf0a-c531-4afc-903e-d79d27c2b4f1",
+  "agent": "human",
+  "model": "Joose Rajamäki",
+  "repo": "why-notes",
+  "repo_url": "git@github.com:JooseRajamaeki/why-notes.git",
+  "dir": "skills/why-notes",
+  "basename": "SKILL.md",
+  "branch": "main",
+  "commit": "7a3a98e",
+  "related": [
+    "280cef8d-0dce-4b39-94dc-f4a0cf240d25",
+    "cc2dd3d5-9e0e-471a-bbd2-a6160d4c7368"
+  ],
+  "note": "Hello, we should add add instructions that there should be an architectural decision per note. So each note should be kept minimal. It's ok and even a good idea to create multiple notes per discussion.",
+  "checksum": "e9a26f37df53864df7e2a7680a59d32c6f936c6250dccd84ab5405d95f5826b4"
+}


### PR DESCRIPTION
Require one architectural decision per note

Encourages splitting a discussion into several minimal, focused notes
instead of bundling unrelated rationale into one entry.