### PR TITLE
Add schema versioning to why-notes (closes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ One JSON per note (rather than an aggregate log) makes the corpus trivially inge
 |-------------|------------|------------------------------------------------------------------------------------------|
 | `timestamp` | string     | ISO 8601 UTC timestamp of when the note was recorded.                                    |
 | `uuid`      | string     | UUIDv4. Suffix of the filename; referenced by other notes' `related`.                    |
+| `version`   | string     | Schema version the note was written under (current: `"1"`). Omitted on pre-versioning notes. |
 | `agent`     | string     | Source: `human` for users, `claude` / `openai` / etc. for AI sources.                    |
 | `model`     | string     | AI model id (e.g. `opus 4.7`) for AI sources; the human's name for human sources.        |
 | `repo`      | string     | Git repository the note refers to (may differ from the cwd).                             |
@@ -73,7 +74,7 @@ One JSON per note (rather than an aggregate log) makes the corpus trivially inge
 | `repo_url` | string     | Git remote URL of the repo at recording time (omitted if unavailable).                   |
 | `related`   | `string[]` | UUIDs of related notes for cross-referencing principles that span files.                 |
 | `note`      | string     | Free-form prose: the rationale, constraint, or tradeoff being recorded.                  |
-| `checksum`  | string     | SHA-256 over the immutable fields (everything except `repo_url`, `related`, `branch`).    |
+| `checksum`  | string     | SHA-256 over the immutable fields (everything except `repo_url`, `related`, `branch`). New immutable fields (currently `version`) are folded into the checksum only when present, so legacy notes still verify. |
 
 `dir` is deliberately repo-relative — never relative to `$WHY_NOTES_DIR` or the cwd — so notes don't leak personal local-filesystem layout when shared.
 

--- a/skills/why-notes/src/note.py
+++ b/skills/why-notes/src/note.py
@@ -16,9 +16,15 @@ from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 
 
+SCHEMA_VERSION = "1"
+
 CHECKSUM_FIELDS = ("agent", "basename", "commit", "dir", "model", "note", "timestamp", "uuid")
+# Immutable fields added after the original schema. Included in the checksum
+# only when present on a given note, so legacy notes (written before the field
+# existed) still verify against their stored checksum.
+CHECKSUM_FIELDS_OPTIONAL = ("version",)
 SERIALIZED_FIELDS = (
-    "timestamp", "uuid", "agent", "model", "repo", "repo_url",
+    "timestamp", "uuid", "version", "agent", "model", "repo", "repo_url",
     "dir", "basename", "branch", "commit", "related", "note", "checksum",
 )
 
@@ -55,6 +61,7 @@ class Note:
     branch: str
     commit: str
     note: str
+    version: str = ""
     repo_url: str = ""
     related: list = field(default_factory=list)
     checksum: str = ""
@@ -67,6 +74,7 @@ class Note:
         n = cls(
             timestamp=datetime.now(timezone.utc).isoformat(),
             uuid=str(uuidlib.uuid4()),
+            version=SCHEMA_VERSION,
             agent=agent,
             model=model,
             repo=repo,
@@ -86,6 +94,7 @@ class Note:
         return cls(
             timestamp=data.get("timestamp", ""),
             uuid=data.get("uuid", ""),
+            version=data.get("version", "") or "",
             agent=data.get("agent", ""),
             model=data.get("model", ""),
             repo=data.get("repo", ""),
@@ -105,10 +114,12 @@ class Note:
         d = {
             "timestamp": self.timestamp,
             "uuid": self.uuid,
-            "agent": self.agent,
-            "model": self.model,
-            "repo": self.repo,
         }
+        if self.version:
+            d["version"] = self.version
+        d["agent"] = self.agent
+        d["model"] = self.model
+        d["repo"] = self.repo
         if self.repo_url:
             d["repo_url"] = self.repo_url
         d["dir"] = self.dir
@@ -122,8 +133,15 @@ class Note:
         return d
 
     def compute_checksum(self):
+        payload_dict = {k: getattr(self, k) for k in CHECKSUM_FIELDS}
+        # Optional fields contribute to the checksum only when present, so
+        # adding a new immutable field doesn't invalidate pre-existing notes.
+        for k in CHECKSUM_FIELDS_OPTIONAL:
+            v = getattr(self, k, "")
+            if v:
+                payload_dict[k] = v
         payload = json.dumps(
-            {k: getattr(self, k) for k in CHECKSUM_FIELDS},
+            payload_dict,
             sort_keys=True,
             separators=(",", ":"),
             ensure_ascii=False,

--- a/why-notes/why-notes/skills/why-notes/src/note.py-dbfaee83-ed75-4d97-9228-fb295179526e.json
+++ b/why-notes/why-notes/skills/why-notes/src/note.py-dbfaee83-ed75-4d97-9228-fb295179526e.json
@@ -1,0 +1,16 @@
+{
+  "timestamp": "2026-05-02T18:03:38.572074+00:00",
+  "uuid": "dbfaee83-ed75-4d97-9228-fb295179526e",
+  "version": "1",
+  "agent": "human",
+  "model": "Joose Rajamäki",
+  "repo": "why-notes",
+  "repo_url": "git@github.com:JooseRajamaeki/why-notes.git",
+  "dir": "skills/why-notes/src",
+  "basename": "note.py",
+  "branch": "feature/note-versioning",
+  "commit": "1b1a801",
+  "related": [],
+  "note": "Let's include the version in the checksum fields. But we can make it so that it's included if it's present so it's backwards compatible. That's also a good general principle to keep the system extendable. The new (immutable) fields should be included in the checksum if they are present.",
+  "checksum": "ad9e81e76744ab864460bbeab7aa3f78d4af34de0a5237e48664aca4d634bb3f"
+}


### PR DESCRIPTION
Each note now carries a `version` field set from a module-level
SCHEMA_VERSION constant (currently "1"). The field is included in the
checksum only when present, so newly written notes get cryptographic
protection on their schema version while pre-versioning notes still
verify against their original checksum. This sets a general pattern
for future immutable-field additions: list them in
CHECKSUM_FIELDS_OPTIONAL and they participate in the checksum if and
only if a given note has them.