### PR TITLE
Add unittest suite for why-notes skill (closes #10)

### DIFF
--- a/skills/why-notes/tests/README.md
+++ b/skills/why-notes/tests/README.md
@@ -1,0 +1,11 @@
+# Tests
+
+Run from the repo root:
+
+```bash
+python3 -m unittest discover -s skills/why-notes/tests -t skills/why-notes/tests
+```
+
+`test_note.py` covers the data model in `src/note.py` (checksum, validators, store I/O). `test_cli.py` runs `record.py` and `consult.py` end-to-end via subprocess in a throwaway git repo with `WHY_NOTES_DIR` pointed at a tempdir.
+
+No third-party dependencies — stdlib `unittest` only.

--- a/skills/why-notes/tests/test_cli.py
+++ b/skills/why-notes/tests/test_cli.py
@@ -1,0 +1,291 @@
+"""End-to-end tests for record.py and consult.py via subprocess.
+
+Each test runs the CLI in an isolated temp git repo and points the
+corpus at a temp directory via WHY_NOTES_DIR.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+RECORD = SRC / "record.py"
+CONSULT = SRC / "consult.py"
+
+
+def init_git_repo(path):
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True, env=env)
+    (Path(path) / "seed.txt").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "seed.txt"], cwd=path, check=True, env=env)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "seed"], cwd=path, check=True, env=env
+    )
+
+
+def run_record(cwd, notes_dir, *args, stdin="", extra_env=None):
+    env = {**os.environ, "WHY_NOTES_DIR": str(notes_dir)}
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [sys.executable, str(RECORD), *args],
+        cwd=cwd,
+        input=stdin,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def run_consult(cwd, notes_dir, *args):
+    env = {**os.environ, "WHY_NOTES_DIR": str(notes_dir)}
+    return subprocess.run(
+        [sys.executable, str(CONSULT), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+class RecordCliTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.repo = Path(self.tmp.name) / "repo"
+        self.repo.mkdir()
+        self.notes = Path(self.tmp.name) / "notes"
+        init_git_repo(self.repo)
+
+    def test_record_writes_note_and_round_trips_through_consult(self):
+        r = run_record(
+            self.repo, self.notes,
+            "--agent", "claude",
+            "--model", "opus 4.7",
+            "--repo", "demo",
+            "--file", "src/foo.py",
+            stdin="because we needed to",
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+        # Exactly one note on disk in the expected location.
+        files = list((self.notes / "demo" / "src").glob("foo.py-*.json"))
+        self.assertEqual(len(files), 1)
+        data = json.loads(files[0].read_text(encoding="utf-8"))
+        self.assertEqual(data["agent"], "claude")
+        self.assertEqual(data["basename"], "foo.py")
+        self.assertEqual(data["dir"], "src")
+        self.assertEqual(data["note"], "because we needed to")
+        self.assertTrue(data["checksum"])
+
+        c = run_consult(self.repo, self.notes, "--repo", "demo", "--file", "src/foo.py")
+        self.assertEqual(c.returncode, 0, c.stderr)
+        self.assertIn("because we needed to", c.stdout)
+        self.assertIn(data["uuid"], c.stdout)
+
+    def test_record_rejects_empty_stdin(self):
+        r = run_record(
+            self.repo, self.notes,
+            "--agent", "claude", "--model", "opus 4.7",
+            "--repo", "demo", "--file", "src/foo.py",
+            stdin="   \n",
+        )
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("empty input", r.stderr)
+
+    def test_record_rejects_oversize_non_human_note(self):
+        big = "x" * 50
+        r = run_record(
+            self.repo, self.notes,
+            "--agent", "claude", "--model", "opus 4.7",
+            "--repo", "demo", "--file", "src/foo.py",
+            "--max-chars", "10",
+            stdin=big,
+        )
+        self.assertEqual(r.returncode, 7)
+        self.assertIn("exceeds --max-chars", r.stderr)
+
+    def test_record_allows_oversize_human_note(self):
+        big = "x" * 50
+        r = run_record(
+            self.repo, self.notes,
+            "--agent", "human", "--model", "Joose",
+            "--repo", "demo", "--file", "src/foo.py",
+            "--max-chars", "10",
+            stdin=big,
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    def test_record_rejects_invalid_repo(self):
+        r = run_record(
+            self.repo, self.notes,
+            "--agent", "claude", "--model", "opus 4.7",
+            "--repo", "../escape", "--file", "src/foo.py",
+            stdin="x",
+        )
+        self.assertEqual(r.returncode, 2)
+
+    def test_record_rejects_invalid_file_path(self):
+        r = run_record(
+            self.repo, self.notes,
+            "--agent", "claude", "--model", "opus 4.7",
+            "--repo", "demo", "--file", "../escape.py",
+            stdin="x",
+        )
+        self.assertEqual(r.returncode, 4)
+
+    def test_record_rejects_invalid_related_uuid(self):
+        r = run_record(
+            self.repo, self.notes,
+            "--agent", "claude", "--model", "opus 4.7",
+            "--repo", "demo", "--file", "src/foo.py",
+            "--related", "not-a-uuid",
+            stdin="x",
+        )
+        self.assertEqual(r.returncode, 5)
+
+    def test_record_fails_outside_git_repo(self):
+        non_git = Path(self.tmp.name) / "plain"
+        non_git.mkdir()
+        r = run_record(
+            non_git, self.notes,
+            "--agent", "claude", "--model", "opus 4.7",
+            "--repo", "demo", "--file", "src/foo.py",
+            stdin="x",
+        )
+        self.assertEqual(r.returncode, 3)
+        self.assertIn("no git commit", r.stderr)
+
+    def test_record_creates_backlink_for_related(self):
+        # First note is the target.
+        r1 = run_record(
+            self.repo, self.notes,
+            "--agent", "claude", "--model", "opus 4.7",
+            "--repo", "demo", "--file", "src/a.py",
+            stdin="first",
+        )
+        self.assertEqual(r1.returncode, 0, r1.stderr)
+        target_path = next((self.notes / "demo" / "src").glob("a.py-*.json"))
+        target_uuid = json.loads(target_path.read_text(encoding="utf-8"))["uuid"]
+
+        # Second note links to it.
+        r2 = run_record(
+            self.repo, self.notes,
+            "--agent", "claude", "--model", "opus 4.7",
+            "--repo", "demo", "--file", "src/b.py",
+            "--related", target_uuid,
+            stdin="second",
+        )
+        self.assertEqual(r2.returncode, 0, r2.stderr)
+        new_uuid = json.loads(
+            next((self.notes / "demo" / "src").glob("b.py-*.json")).read_text(
+                encoding="utf-8"
+            )
+        )["uuid"]
+
+        patched = json.loads(target_path.read_text(encoding="utf-8"))
+        self.assertIn(new_uuid, patched["related"])
+
+    def test_record_warns_on_unknown_related_uuid(self):
+        unknown = "11111111-1111-1111-1111-111111111111"
+        r = run_record(
+            self.repo, self.notes,
+            "--agent", "claude", "--model", "opus 4.7",
+            "--repo", "demo", "--file", "src/foo.py",
+            "--related", unknown,
+            stdin="x",
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("not found", r.stderr)
+
+
+class ConsultCliTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.repo = Path(self.tmp.name) / "repo"
+        self.repo.mkdir()
+        self.notes = Path(self.tmp.name) / "notes"
+        init_git_repo(self.repo)
+
+    def test_consult_with_no_notes_dir_returns_zero_with_message(self):
+        r = run_consult(
+            self.repo, self.notes, "--repo", "demo", "--file", "src/foo.py"
+        )
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("no notes", r.stderr)
+
+    def test_consult_flags_tampered_note(self):
+        r = run_record(
+            self.repo, self.notes,
+            "--agent", "claude", "--model", "opus 4.7",
+            "--repo", "demo", "--file", "src/foo.py",
+            stdin="original",
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+        path = next((self.notes / "demo" / "src").glob("foo.py-*.json"))
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data["note"] = "edited after the fact"
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+        c = run_consult(
+            self.repo, self.notes, "--repo", "demo", "--file", "src/foo.py"
+        )
+        self.assertEqual(c.returncode, 0, c.stderr)
+        self.assertIn("failed checksum", c.stderr)
+
+    def test_consult_follows_related_cross_references(self):
+        # Note A.
+        r1 = run_record(
+            self.repo, self.notes,
+            "--agent", "claude", "--model", "opus 4.7",
+            "--repo", "demo", "--file", "src/a.py",
+            stdin="rationale A",
+        )
+        self.assertEqual(r1.returncode, 0, r1.stderr)
+        a_uuid = json.loads(
+            next((self.notes / "demo" / "src").glob("a.py-*.json")).read_text(
+                encoding="utf-8"
+            )
+        )["uuid"]
+
+        # Note B links to A.
+        r2 = run_record(
+            self.repo, self.notes,
+            "--agent", "claude", "--model", "opus 4.7",
+            "--repo", "demo", "--file", "src/b.py",
+            "--related", a_uuid,
+            stdin="rationale B references A",
+        )
+        self.assertEqual(r2.returncode, 0, r2.stderr)
+
+        # Consulting B should surface A as a related note.
+        c = run_consult(
+            self.repo, self.notes, "--repo", "demo", "--file", "src/b.py"
+        )
+        self.assertEqual(c.returncode, 0, c.stderr)
+        self.assertIn("rationale B references A", c.stdout)
+        self.assertIn("rationale A", c.stdout)
+        self.assertIn("Related notes", c.stdout)
+
+    def test_consult_rejects_invalid_repo(self):
+        c = run_consult(
+            self.repo, self.notes, "--repo", "../escape", "--file", "src/foo.py"
+        )
+        self.assertEqual(c.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/why-notes/tests/test_note.py
+++ b/skills/why-notes/tests/test_note.py
@@ -1,0 +1,279 @@
+"""Unit tests for the why-notes data model in src/note.py."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path, PurePosixPath
+from unittest import mock
+
+SRC = Path(__file__).resolve().parent.parent / "src"
+sys.path.insert(0, str(SRC))
+
+from note import (  # noqa: E402
+    CHECKSUM_FIELDS,
+    CHECKSUM_FIELDS_OPTIONAL,
+    SCHEMA_VERSION,
+    Note,
+    NotesStore,
+    validate_file_rel,
+    validate_repo,
+    validate_uuids,
+)
+
+
+def make_note(**overrides):
+    defaults = dict(
+        agent="claude",
+        model="opus 4.7",
+        repo="why-notes",
+        repo_url="https://example.com/repo",
+        file_rel=PurePosixPath("src/note.py"),
+        branch="main",
+        commit="abc1234",
+        related=[],
+        note="some rationale",
+    )
+    defaults.update(overrides)
+    return Note.create(**defaults)
+
+
+class ValidatorTests(unittest.TestCase):
+    def test_validate_repo_rejects_separators_and_traversal(self):
+        for bad in ("a/b", "..", ".hidden", "x/../y"):
+            with self.assertRaises(ValueError):
+                validate_repo(bad)
+
+    def test_validate_repo_accepts_plain_name(self):
+        validate_repo("why-notes")  # no exception
+
+    def test_validate_file_rel_rejects_absolute_and_traversal(self):
+        for bad in ("/etc/passwd", "../escape.py", "a/../b.py", ""):
+            with self.assertRaises(ValueError):
+                validate_file_rel(bad)
+
+    def test_validate_file_rel_returns_pureposixpath(self):
+        p = validate_file_rel("src/auth/login.py")
+        self.assertIsInstance(p, PurePosixPath)
+        self.assertEqual(p.name, "login.py")
+        self.assertEqual(str(p.parent), "src/auth")
+
+    def test_validate_uuids_rejects_garbage(self):
+        with self.assertRaises(ValueError):
+            validate_uuids(["not-a-uuid"])
+
+    def test_validate_uuids_accepts_valid(self):
+        validate_uuids(["12345678-1234-5678-1234-567812345678"])  # no exception
+
+
+class NoteChecksumTests(unittest.TestCase):
+    def test_create_populates_checksum_and_verifies(self):
+        n = make_note()
+        self.assertTrue(n.checksum)
+        self.assertEqual(n.verify(), "valid")
+
+    def test_checksum_includes_version_when_present(self):
+        # Hand-build a legacy note with no version, checksum'd over base fields.
+        legacy = make_note()
+        legacy.version = ""
+        legacy.checksum = legacy.compute_checksum()
+        self.assertEqual(legacy.verify(), "valid")
+        # Same fields but with version set should produce a *different* checksum.
+        modern = make_note()
+        modern.version = SCHEMA_VERSION
+        modern.checksum = modern.compute_checksum()
+        self.assertNotEqual(legacy.checksum, modern.checksum)
+
+    def test_legacy_note_without_version_still_verifies(self):
+        # Simulate a note saved before the version field existed.
+        n = make_note()
+        n.version = ""
+        n.checksum = n.compute_checksum()
+        # Round-trip through dict to mimic on-disk read.
+        round_tripped = Note.from_dict(n.to_dict())
+        self.assertEqual(round_tripped.verify(), "valid")
+
+    def test_tampered_note_flagged(self):
+        n = make_note()
+        n.note = "edited after recording"
+        self.assertEqual(n.verify(), "tampered")
+
+    def test_no_checksum_returns_no_checksum(self):
+        n = make_note()
+        n.checksum = ""
+        self.assertEqual(n.verify(), "no_checksum")
+
+    def test_related_field_excluded_from_checksum(self):
+        # Backlinks must not invalidate the referenced note's checksum.
+        n = make_note()
+        original = n.checksum
+        n.related.append("11111111-1111-1111-1111-111111111111")
+        self.assertEqual(n.verify(), "valid")
+        self.assertEqual(n.compute_checksum(), original)
+
+    def test_checksum_field_lists_have_no_overlap(self):
+        self.assertEqual(set(CHECKSUM_FIELDS) & set(CHECKSUM_FIELDS_OPTIONAL), set())
+
+
+class NoteSerializationTests(unittest.TestCase):
+    def test_to_dict_round_trip(self):
+        n = make_note(related=["aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"])
+        d = n.to_dict()
+        n2 = Note.from_dict(d)
+        self.assertEqual(n2.to_dict(), d)
+        self.assertEqual(n2.verify(), "valid")
+
+    def test_to_dict_omits_empty_optional_fields(self):
+        n = make_note()
+        n.repo_url = ""
+        n.version = ""
+        n.checksum = ""
+        d = n.to_dict()
+        self.assertNotIn("repo_url", d)
+        self.assertNotIn("version", d)
+        self.assertNotIn("checksum", d)
+
+    def test_dir_empty_when_file_at_repo_root(self):
+        n = make_note(file_rel=PurePosixPath("README.md"))
+        self.assertEqual(n.dir, "")
+        self.assertEqual(n.basename, "README.md")
+
+    def test_location_format(self):
+        n = make_note()
+        self.assertEqual(n.location(), "why-notes/src/note.py")
+        flat = make_note(file_rel=PurePosixPath("README.md"))
+        self.assertEqual(flat.location(), "why-notes/README.md")
+
+
+class NotesStoreTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.store = NotesStore(self.tmp.name)
+
+    def test_path_for_includes_dir(self):
+        n = make_note()
+        p = self.store.path_for(n)
+        expected = (
+            Path(self.tmp.name) / "why-notes" / "src" / f"note.py-{n.uuid}.json"
+        )
+        self.assertEqual(p, expected)
+
+    def test_path_for_root_file(self):
+        n = make_note(file_rel=PurePosixPath("README.md"))
+        p = self.store.path_for(n)
+        expected = Path(self.tmp.name) / "why-notes" / f"README.md-{n.uuid}.json"
+        self.assertEqual(p, expected)
+
+    def test_write_creates_parent_dirs(self):
+        n = make_note()
+        p = self.store.write(n)
+        self.assertTrue(p.is_file())
+        loaded = json.loads(p.read_text(encoding="utf-8"))
+        self.assertEqual(loaded["uuid"], n.uuid)
+
+    def test_primaries_for_returns_only_matching_file(self):
+        n1 = make_note(file_rel=PurePosixPath("src/note.py"))
+        n2 = make_note(file_rel=PurePosixPath("src/note.py"))
+        other = make_note(file_rel=PurePosixPath("src/record.py"))
+        self.store.write(n1)
+        self.store.write(n2)
+        self.store.write(other)
+        got = self.store.primaries_for("why-notes", PurePosixPath("src/note.py"))
+        uuids = {n.uuid for n in got}
+        self.assertEqual(uuids, {n1.uuid, n2.uuid})
+
+    def test_primaries_for_root_file(self):
+        n = make_note(file_rel=PurePosixPath("README.md"))
+        self.store.write(n)
+        got = self.store.primaries_for("why-notes", PurePosixPath("README.md"))
+        self.assertEqual([m.uuid for m in got], [n.uuid])
+
+    def test_primaries_for_missing_dir_returns_empty(self):
+        self.assertEqual(
+            self.store.primaries_for("nonexistent", PurePosixPath("x.py")),
+            [],
+        )
+
+    def test_iter_notes_skips_invalid_json(self):
+        n = make_note()
+        self.store.write(n)
+        # Drop a malformed file that matches *.json.
+        bad = Path(self.tmp.name) / "why-notes" / "src" / "garbage.json"
+        bad.write_text("{not json", encoding="utf-8")
+        uuids = [note.uuid for _, note in self.store.iter_notes()]
+        self.assertIn(n.uuid, uuids)
+
+    def test_index_by_uuid(self):
+        n = make_note()
+        self.store.write(n)
+        idx = self.store.index_by_uuid()
+        self.assertIn(n.uuid, idx)
+        _, found = idx[n.uuid]
+        self.assertEqual(found.uuid, n.uuid)
+
+    def test_add_backlink_appends_uuid(self):
+        target = make_note()
+        self.store.write(target)
+        new_uuid = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        patched = self.store.add_backlink(target.uuid, new_uuid)
+        self.assertIsNotNone(patched)
+        loaded = json.loads(patched.read_text(encoding="utf-8"))
+        self.assertIn(new_uuid, loaded["related"])
+
+    def test_add_backlink_idempotent(self):
+        target = make_note()
+        self.store.write(target)
+        u = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+        self.store.add_backlink(target.uuid, u)
+        self.store.add_backlink(target.uuid, u)
+        loaded = json.loads(self.store.path_for(target).read_text(encoding="utf-8"))
+        self.assertEqual(loaded["related"].count(u), 1)
+
+    def test_add_backlink_preserves_target_checksum(self):
+        target = make_note()
+        original_checksum = target.checksum
+        self.store.write(target)
+        self.store.add_backlink(
+            target.uuid, "dddddddd-dddd-dddd-dddd-dddddddddddd"
+        )
+        loaded = json.loads(self.store.path_for(target).read_text(encoding="utf-8"))
+        self.assertEqual(loaded["checksum"], original_checksum)
+        # And the loaded note still verifies.
+        self.assertEqual(Note.from_dict(loaded).verify(), "valid")
+
+    def test_add_backlink_missing_target_returns_none(self):
+        result = self.store.add_backlink(
+            "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+            "ffffffff-ffff-ffff-ffff-ffffffffffff",
+        )
+        self.assertIsNone(result)
+
+
+class NotesStoreResolveTests(unittest.TestCase):
+    def test_env_var_wins(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.dict(os.environ, {"WHY_NOTES_DIR": tmp}):
+                store = NotesStore.resolve(cwd="/does/not/matter")
+                self.assertEqual(store.root, Path(tmp))
+
+    def test_falls_back_to_git_root(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env = {k: v for k, v in os.environ.items() if k != "WHY_NOTES_DIR"}
+            with mock.patch.dict(os.environ, env, clear=True):
+                with mock.patch("note.git", return_value=tmp):
+                    store = NotesStore.resolve(cwd=tmp)
+                    self.assertEqual(store.root, Path(tmp) / "why-notes")
+
+    def test_falls_back_to_cwd_when_no_git(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env = {k: v for k, v in os.environ.items() if k != "WHY_NOTES_DIR"}
+            with mock.patch.dict(os.environ, env, clear=True):
+                with mock.patch("note.git", return_value=""):
+                    store = NotesStore.resolve(cwd=tmp)
+                    self.assertEqual(store.root, Path(tmp) / "why-notes")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/why-notes/why-notes/README.md-17d9efea-4200-4bc5-ad42-c4ece64c862d.json
+++ b/why-notes/why-notes/README.md-17d9efea-4200-4bc5-ad42-c4ece64c862d.json
@@ -1,0 +1,16 @@
+{
+  "timestamp": "2026-05-02T18:21:43.272147+00:00",
+  "uuid": "17d9efea-4200-4bc5-ad42-c4ece64c862d",
+  "version": "1",
+  "agent": "human",
+  "model": "Joose Rajamäki",
+  "repo": "why-notes",
+  "repo_url": "git@github.com:JooseRajamaeki/why-notes.git",
+  "dir": "",
+  "basename": "README.md",
+  "branch": "main",
+  "commit": "4e365b4",
+  "related": [],
+  "note": "The Github Actions, which potentially costs money was not worth it for a hobby project.",
+  "checksum": "a523bb3abf0521d0c529e2a150f507c54a87dc598c311614e00f81d09eab22ae"
+}

--- a/why-notes/why-notes/README.md-d349d35f-bb83-45ef-a351-6881903364bf.json
+++ b/why-notes/why-notes/README.md-d349d35f-bb83-45ef-a351-6881903364bf.json
@@ -1,0 +1,16 @@
+{
+  "timestamp": "2026-05-02T18:21:31.259933+00:00",
+  "uuid": "d349d35f-bb83-45ef-a351-6881903364bf",
+  "version": "1",
+  "agent": "human",
+  "model": "Joose Rajamäki",
+  "repo": "why-notes",
+  "repo_url": "git@github.com:JooseRajamaeki/why-notes.git",
+  "dir": "",
+  "basename": "README.md",
+  "branch": "main",
+  "commit": "4e365b4",
+  "related": [],
+  "note": "I want to keep the project dependency free.",
+  "checksum": "2941bee61ff5b24b67b372f65c343f83e968fa8854c73284b9719fee49e69ae7"
+}

--- a/why-notes/why-notes/skills/why-notes/tests/test_cli.py-6c8fda1c-ff4c-496f-ad08-1964d4e81e54.json
+++ b/why-notes/why-notes/skills/why-notes/tests/test_cli.py-6c8fda1c-ff4c-496f-ad08-1964d4e81e54.json
@@ -1,0 +1,16 @@
+{
+  "timestamp": "2026-05-02T18:22:22.880442+00:00",
+  "uuid": "6c8fda1c-ff4c-496f-ad08-1964d4e81e54",
+  "version": "1",
+  "agent": "claude",
+  "model": "opus 4.7",
+  "repo": "why-notes",
+  "repo_url": "git@github.com:JooseRajamaeki/why-notes.git",
+  "dir": "skills/why-notes/tests",
+  "basename": "test_cli.py",
+  "branch": "main",
+  "commit": "4e365b4",
+  "related": [],
+  "note": "CLI tests run record.py and consult.py via subprocess in a throwaway git repo, with WHY_NOTES_DIR pointing at a tempdir under TemporaryDirectory(). This piggybacks on the corpus-resolution precedence already in NotesStore.resolve (env var beats git-root and cwd), so tests exercise the same code path that production runs while staying isolated from the real why-notes/ corpus. Without WHY_NOTES_DIR, the CLI would resolve to the repo's own why-notes/ directory and pollute the live corpus during test runs.",
+  "checksum": "05dd1b1c671b9fbf5b3d8fdd9b4579d3cb21dc326b88dbd131808e628b1002d1"
+}


### PR DESCRIPTION
46 tests covering the data model in src/note.py (checksum, validators, NotesStore I/O, resolve precedence) and end-to-end CLI behavior of record.py and consult.py via subprocess in a throwaway git repo. Stdlib unittest only — no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)