### PR TITLE
why-notes: self-describing checksum_fields + unittest suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Run `--help` for the full contract. See `skills/why-notes/SKILL.md` for the agen
 
 ### `src/consult.py` — the lookup
 
-Before reading or editing a file, surface the prior rationale anchored to it. Notes print newest-first; when entries conflict, the most recent timestamp wins. Each loaded note's checksum is verified; tampered notes are flagged on stderr.
+Before reading or editing a file, surface the prior rationale anchored to it. Notes print newest-first; when entries conflict, the most recent timestamp wins. Each loaded note's checksum is verified; corrupted notes are flagged on stderr.
 
 **Example invocation** (placeholder values — substitute the repo and file you're about to work on):
 

--- a/skills/why-notes/src/consult.py
+++ b/skills/why-notes/src/consult.py
@@ -51,7 +51,7 @@ def main():
             "list across the entire local notes corpus; cycles are detected "
             "and unresolved UUIDs (e.g. references into another corpus) are "
             "listed separately. Each loaded note's checksum is verified; "
-            "tampered notes are flagged on stderr."
+            "corrupted notes are flagged on stderr."
         ),
     )
     parser.add_argument(
@@ -130,16 +130,16 @@ def main():
         uniq = sorted(set(unresolved))
         print(f"Unresolved related UUIDs (not found in local corpus): {', '.join(uniq)}")
 
-    tampered = [n for n in (*primaries, *related_notes) if n.verify() == "tampered"]
+    corrupted = [n for n in (*primaries, *related_notes) if n.verify() == "corrupted"]
     legacy = sum(1 for n in (*primaries, *related_notes) if n.verify() == "no_checksum")
-    if tampered:
+    if corrupted:
         print(file=sys.stderr)
         print(
-            f"consult: WARNING — {len(tampered)} note(s) failed checksum verification "
-            "(content may have been edited after recording):",
+            f"consult: WARNING — {len(corrupted)} note(s) failed checksum verification "
+            "(content may have been altered since recording — accidentally or otherwise):",
             file=sys.stderr,
         )
-        for n in tampered:
+        for n in corrupted:
             print(f"  {n.uuid}  {n.location()}", file=sys.stderr)
     if legacy:
         print(

--- a/skills/why-notes/src/note.py
+++ b/skills/why-notes/src/note.py
@@ -18,14 +18,19 @@ from pathlib import Path, PurePosixPath
 
 SCHEMA_VERSION = "1"
 
-CHECKSUM_FIELDS = ("agent", "basename", "commit", "dir", "model", "note", "timestamp", "uuid")
-# Immutable fields added after the original schema. Included in the checksum
-# only when present on a given note, so legacy notes (written before the field
-# existed) still verify against their stored checksum.
-CHECKSUM_FIELDS_OPTIONAL = ("version",)
+# Canonical fields hashed into the checksum for newly-created notes. Each note
+# stores its own `checksum_fields` list, so this constant only seeds new notes;
+# verification reads the list off the note itself. `"checksum_fields"` is in
+# the list, making the checksum self-referential — altering the field list
+# invalidates the hash.
+CHECKSUM_FIELDS = (
+    "agent", "basename", "checksum_fields", "commit", "dir",
+    "model", "note", "timestamp", "uuid", "version",
+)
 SERIALIZED_FIELDS = (
     "timestamp", "uuid", "version", "agent", "model", "repo", "repo_url",
-    "dir", "basename", "branch", "commit", "related", "note", "checksum",
+    "dir", "basename", "branch", "commit", "related", "note",
+    "checksum_fields", "checksum",
 )
 
 
@@ -64,6 +69,7 @@ class Note:
     version: str = ""
     repo_url: str = ""
     related: list = field(default_factory=list)
+    checksum_fields: list = field(default_factory=list)
     checksum: str = ""
 
     @classmethod
@@ -85,6 +91,7 @@ class Note:
             commit=commit,
             related=list(related or []),
             note=note,
+            checksum_fields=list(CHECKSUM_FIELDS),
         )
         n.checksum = n.compute_checksum()
         return n
@@ -105,6 +112,7 @@ class Note:
             commit=data.get("commit", ""),
             related=list(data.get("related") or []),
             note=data.get("note", ""),
+            checksum_fields=list(data.get("checksum_fields") or []),
             checksum=data.get("checksum", "") or "",
         )
 
@@ -128,18 +136,14 @@ class Note:
         d["commit"] = self.commit
         d["related"] = list(self.related)
         d["note"] = self.note
+        if self.checksum_fields:
+            d["checksum_fields"] = list(self.checksum_fields)
         if self.checksum:
             d["checksum"] = self.checksum
         return d
 
     def compute_checksum(self):
-        payload_dict = {k: getattr(self, k) for k in CHECKSUM_FIELDS}
-        # Optional fields contribute to the checksum only when present, so
-        # adding a new immutable field doesn't invalidate pre-existing notes.
-        for k in CHECKSUM_FIELDS_OPTIONAL:
-            v = getattr(self, k, "")
-            if v:
-                payload_dict[k] = v
+        payload_dict = {k: getattr(self, k) for k in self.checksum_fields}
         payload = json.dumps(
             payload_dict,
             sort_keys=True,
@@ -149,10 +153,15 @@ class Note:
         return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
     def verify(self):
-        """Return 'valid', 'tampered', or 'no_checksum'."""
-        if not self.checksum:
+        """Return 'valid', 'corrupted', or 'no_checksum'.
+
+        An empty `checksum_fields` means the note declares no integrity
+        coverage (legacy notes written before the self-describing scheme),
+        so verification is skipped and reported as 'no_checksum'.
+        """
+        if not self.checksum_fields or not self.checksum:
             return "no_checksum"
-        return "valid" if self.checksum == self.compute_checksum() else "tampered"
+        return "valid" if self.checksum == self.compute_checksum() else "corrupted"
 
     def location(self):
         d = self.dir or ""

--- a/skills/why-notes/src/note.py
+++ b/skills/why-notes/src/note.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 
 
-SCHEMA_VERSION = "1"
+SCHEMA_VERSION = "2.0.0"
 
 # Canonical fields hashed into the checksum for newly-created notes. Each note
 # stores its own `checksum_fields` list, so this constant only seeds new notes;

--- a/skills/why-notes/tests/test_cli.py
+++ b/skills/why-notes/tests/test_cli.py
@@ -226,7 +226,7 @@ class ConsultCliTests(unittest.TestCase):
         self.assertEqual(r.returncode, 0)
         self.assertIn("no notes", r.stderr)
 
-    def test_consult_flags_tampered_note(self):
+    def test_consult_flags_corrupted_note(self):
         r = run_record(
             self.repo, self.notes,
             "--agent", "claude", "--model", "opus 4.7",

--- a/skills/why-notes/tests/test_note.py
+++ b/skills/why-notes/tests/test_note.py
@@ -13,7 +13,6 @@ sys.path.insert(0, str(SRC))
 
 from note import (  # noqa: E402
     CHECKSUM_FIELDS,
-    CHECKSUM_FIELDS_OPTIONAL,
     SCHEMA_VERSION,
     Note,
     NotesStore,
@@ -73,35 +72,52 @@ class NoteChecksumTests(unittest.TestCase):
         self.assertTrue(n.checksum)
         self.assertEqual(n.verify(), "valid")
 
-    def test_checksum_includes_version_when_present(self):
-        # Hand-build a legacy note with no version, checksum'd over base fields.
-        legacy = make_note()
-        legacy.version = ""
-        legacy.checksum = legacy.compute_checksum()
-        self.assertEqual(legacy.verify(), "valid")
-        # Same fields but with version set should produce a *different* checksum.
-        modern = make_note()
-        modern.version = SCHEMA_VERSION
-        modern.checksum = modern.compute_checksum()
-        self.assertNotEqual(legacy.checksum, modern.checksum)
-
-    def test_legacy_note_without_version_still_verifies(self):
-        # Simulate a note saved before the version field existed.
+    def test_create_stores_canonical_checksum_fields(self):
         n = make_note()
-        n.version = ""
-        n.checksum = n.compute_checksum()
-        # Round-trip through dict to mimic on-disk read.
-        round_tripped = Note.from_dict(n.to_dict())
-        self.assertEqual(round_tripped.verify(), "valid")
+        self.assertEqual(list(n.checksum_fields), list(CHECKSUM_FIELDS))
 
-    def test_tampered_note_flagged(self):
+    def test_checksum_is_self_referential(self):
+        # Altering checksum_fields invalidates the hash, because
+        # "checksum_fields" is itself one of the hashed fields.
+        n = make_note()
+        n.checksum_fields = [f for f in n.checksum_fields if f != "version"]
+        self.assertEqual(n.verify(), "corrupted")
+
+    def test_legacy_note_without_checksum_fields_is_no_checksum(self):
+        # Notes written before the self-describing scheme have no
+        # checksum_fields on disk; from_dict defaults to an empty list and
+        # verify reports 'no_checksum' regardless of the stored hash.
+        legacy_data = {
+            "timestamp": "2026-01-01T00:00:00+00:00",
+            "uuid": "11111111-1111-1111-1111-111111111111",
+            "agent": "claude",
+            "model": "opus 4.6",
+            "repo": "why-notes",
+            "dir": "src",
+            "basename": "note.py",
+            "branch": "main",
+            "commit": "deadbee",
+            "related": [],
+            "note": "legacy rationale",
+            "checksum": "0" * 64,
+        }
+        n = Note.from_dict(legacy_data)
+        self.assertEqual(n.checksum_fields, [])
+        self.assertEqual(n.verify(), "no_checksum")
+
+    def test_corrupted_note_flagged(self):
         n = make_note()
         n.note = "edited after recording"
-        self.assertEqual(n.verify(), "tampered")
+        self.assertEqual(n.verify(), "corrupted")
 
     def test_no_checksum_returns_no_checksum(self):
         n = make_note()
         n.checksum = ""
+        self.assertEqual(n.verify(), "no_checksum")
+
+    def test_empty_checksum_fields_returns_no_checksum(self):
+        n = make_note()
+        n.checksum_fields = []
         self.assertEqual(n.verify(), "no_checksum")
 
     def test_related_field_excluded_from_checksum(self):
@@ -112,8 +128,11 @@ class NoteChecksumTests(unittest.TestCase):
         self.assertEqual(n.verify(), "valid")
         self.assertEqual(n.compute_checksum(), original)
 
-    def test_checksum_field_lists_have_no_overlap(self):
-        self.assertEqual(set(CHECKSUM_FIELDS) & set(CHECKSUM_FIELDS_OPTIONAL), set())
+    def test_canonical_checksum_fields_contains_version_and_self(self):
+        self.assertIn("version", CHECKSUM_FIELDS)
+        self.assertIn("checksum_fields", CHECKSUM_FIELDS)
+        # Used by new notes, so SCHEMA_VERSION must be a non-empty string.
+        self.assertTrue(SCHEMA_VERSION)
 
 
 class NoteSerializationTests(unittest.TestCase):
@@ -128,10 +147,12 @@ class NoteSerializationTests(unittest.TestCase):
         n = make_note()
         n.repo_url = ""
         n.version = ""
+        n.checksum_fields = []
         n.checksum = ""
         d = n.to_dict()
         self.assertNotIn("repo_url", d)
         self.assertNotIn("version", d)
+        self.assertNotIn("checksum_fields", d)
         self.assertNotIn("checksum", d)
 
     def test_dir_empty_when_file_at_repo_root(self):

--- a/why-notes/why-notes/skills/why-notes/src/note.py-0bc0bdcd-75ac-41e0-bb05-733f3667c05f.json
+++ b/why-notes/why-notes/skills/why-notes/src/note.py-0bc0bdcd-75ac-41e0-bb05-733f3667c05f.json
@@ -1,0 +1,18 @@
+{
+  "timestamp": "2026-05-13T15:55:10.980413+00:00",
+  "uuid": "0bc0bdcd-75ac-41e0-bb05-733f3667c05f",
+  "version": "1",
+  "agent": "human",
+  "model": "Joose Rajamäki",
+  "repo": "why-notes",
+  "repo_url": "git@github.com:JooseRajamaeki/why-notes.git",
+  "dir": "skills/why-notes/src",
+  "basename": "note.py",
+  "branch": "tests/add-unittest-suite",
+  "commit": "8fedcc2",
+  "related": [
+    "dbfaee83-ed75-4d97-9228-fb295179526e"
+  ],
+  "note": "Hello, we should make it such that the fields for computing the why-note hash are included in a field in the why-note. This way also the notes before versioning are valid because you can include what was used to compute the checksum hash. When the checksum data struct has been added after this modification, it can be self referential, i.e. the list of fields to use for the checksum can itself affect the checksum.\n\nWe don't need to retain the old legacy behavior. For the existing notes we can use empty list. The empty list communicates that no checksum should be applicable. Also the loader can skip checking the checksum for empty lists. The CHECKSUM_FIELDS and the optional fields should be merged to a single list in each note's checksum_fields. The optional ones were always a backwards compatibility solution so they can be equal fields in the CHECKSUM_FIELDS now that the notes will themselves keep track of what affects the checksum.",
+  "checksum": "1275c810caa7cc997e9f48388f0a28f21aaa5dbefb9d66df40cae9b2f4e6207a"
+}

--- a/why-notes/why-notes/skills/why-notes/src/note.py-2b526d18-9000-4246-b918-f77f0ca4dbac.json
+++ b/why-notes/why-notes/skills/why-notes/src/note.py-2b526d18-9000-4246-b918-f77f0ca4dbac.json
@@ -1,0 +1,28 @@
+{
+  "timestamp": "2026-05-13T16:00:55.348942+00:00",
+  "uuid": "2b526d18-9000-4246-b918-f77f0ca4dbac",
+  "version": "1",
+  "agent": "human",
+  "model": "Joose Rajamäki",
+  "repo": "why-notes",
+  "repo_url": "git@github.com:JooseRajamaeki/why-notes.git",
+  "dir": "skills/why-notes/src",
+  "basename": "note.py",
+  "branch": "tests/add-unittest-suite",
+  "commit": "8fedcc2",
+  "related": [],
+  "note": "We should also change the term \"tampered\" to \"corrupted\". Tampered communicates some sort of intention. It's much more likely that the notes are corrupted by accident in a migration for instance.",
+  "checksum_fields": [
+    "agent",
+    "basename",
+    "checksum_fields",
+    "commit",
+    "dir",
+    "model",
+    "note",
+    "timestamp",
+    "uuid",
+    "version"
+  ],
+  "checksum": "c8c4db092f3b4df8a8c20d0f808e9ba5cf45906ce018abe1c119d47077473fe7"
+}

--- a/why-notes/why-notes/skills/why-notes/src/note.py-dbfaee83-ed75-4d97-9228-fb295179526e.json
+++ b/why-notes/why-notes/skills/why-notes/src/note.py-dbfaee83-ed75-4d97-9228-fb295179526e.json
@@ -10,7 +10,9 @@
   "basename": "note.py",
   "branch": "feature/note-versioning",
   "commit": "1b1a801",
-  "related": [],
+  "related": [
+    "0bc0bdcd-75ac-41e0-bb05-733f3667c05f"
+  ],
   "note": "Let's include the version in the checksum fields. But we can make it so that it's included if it's present so it's backwards compatible. That's also a good general principle to keep the system extendable. The new (immutable) fields should be included in the checksum if they are present.",
   "checksum": "ad9e81e76744ab864460bbeab7aa3f78d4af34de0a5237e48664aca4d634bb3f"
 }


### PR DESCRIPTION
## Changes

- **Unittest suite** (closes #10) — `skills/why-notes/tests/test_note.py` and `test_cli.py`, 48 tests covering the data model, store, and CLI round-trips.
- **Self-describing checksums** — each note stores the `checksum_fields` list it was hashed against; `"checksum_fields"` is itself in that list, so the hash is self-referential. The previous `CHECKSUM_FIELDS` / `CHECKSUM_FIELDS_OPTIONAL` split is gone; on-disk legacy notes (no `checksum_fields` field) load with an empty list and `verify()` reports them as `no_checksum`.
- **`tampered` → `corrupted`** — across `note.py`, `consult.py`, the README, and tests. Accidental corruption (migration, manual edit, encoding drift) is far more likely than intent.
- **SCHEMA_VERSION → "2.0.0"** — adopts `MAJOR.MINOR.PATCH`; MAJOR bump because notes that verified as `valid` under "1" now report `no_checksum`.

## Test plan

- [x] `python3 -m unittest discover -s skills/why-notes/tests` — 48/48 pass
- [x] `consult.py` smoke run on this repo's corpus: legacy notes report as `no_checksum`, new notes verify as `valid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)