### PR TITLE
Track rebase/amend rewrites in note commit chain (closes #8)

### DIFF
--- a/.githooks/post-rewrite
+++ b/.githooks/post-rewrite
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Keep why-notes' commit anchors current across rebases and amends.
+# Git invokes this with stdin lines of `<old-sha> <new-sha>` for every
+# rewritten commit. Enable for this repo with:
+#   git config core.hooksPath .githooks
+set -euo pipefail
+REPO_ROOT=$(git rev-parse --show-toplevel)
+exec python3 "$REPO_ROOT/skills/why-notes/src/rewrite.py" --stdin

--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ One JSON per note (rather than an aggregate log) makes the corpus trivially inge
 |-------------|------------|------------------------------------------------------------------------------------------|
 | `timestamp` | string     | ISO 8601 UTC timestamp of when the note was recorded.                                    |
 | `uuid`      | string     | UUIDv4. Suffix of the filename; referenced by other notes' `related`.                    |
-| `version`   | string     | Schema version the note was written under (current: `"1"`). Omitted on pre-versioning notes. |
+| `version`   | string     | Schema version the note was written under (current: `"3.0.0"`). Omitted on pre-versioning notes. |
 | `agent`     | string     | Source: `human` for users, `claude` / `openai` / etc. for AI sources.                    |
 | `model`     | string     | AI model id (e.g. `opus 4.7`) for AI sources; the human's name for human sources.        |
 | `repo`      | string     | Git repository the note refers to (may differ from the cwd).                             |
 | `dir`       | string     | Parent directory of the noted file, relative to the repo root (`""` if at root).         |
 | `basename`  | string     | File name within the repo.                                                               |
 | `branch`    | string     | Git branch of the cwd repo at recording time.                                            |
-| `commit`    | string     | Short git commit hash of the cwd repo at recording time. Required.                       |
+| `commit`    | `string[]` | Short commit hashes anchoring the note, oldest first; the last entry is current. New entries are appended when a rebase or amend rewrites a referenced commit (see `.githooks/post-rewrite`). Legacy v2 notes store a single string. Required. |
 | `repo_url` | string     | Git remote URL of the repo at recording time (omitted if unavailable).                   |
 | `related`   | `string[]` | UUIDs of related notes for cross-referencing principles that span files.                 |
 | `note`      | string     | Free-form prose: the rationale, constraint, or tradeoff being recorded.                  |
@@ -83,7 +83,7 @@ One JSON per note (rather than an aggregate log) makes the corpus trivially inge
 - **Verbatim human input.** When `--agent human`, the user's words are recorded unchanged. No paraphrasing, no summarising. Different humans (or the same human across sessions) are disambiguated by `--model <name>`.
 - **Commit anchor required.** The recorder fails if the cwd is not in a git repo with at least one commit. Every note ties to a codebase snapshot.
 - **Recency wins.** When notes conflict, the newer one supersedes. `consult.py` surfaces newest-first to make this obvious.
-- **Append-only corpus.** Existing JSON files under `why-notes/` are immutable history. Don't edit or delete them by hand; the only legitimate mutations are adding new notes (each is a new file) and the recorder's automatic backlink patches to `related`.
+- **Append-only corpus.** Existing JSON files under `why-notes/` are immutable history. Don't edit or delete them by hand; the only legitimate mutations are adding new notes (each is a new file), the recorder's automatic backlink patches to `related`, and the rewrite tool's appends to `commit` when a rebase or amend changes the referenced SHA.
 - **Skip the obvious.** Don't record what the code already shows or the commit message already explains. Notes are for the *why* that would otherwise be lost.
 - **Standard library only.** Scripts in this repo must not import anything outside the Python standard library. No `pip install`, no `requirements.txt`, no virtualenv — the tools must run on a bare-bones machine with only `python3` and `git` available. Reach for the stdlib (or shell out to `git`) before introducing any third-party dependency.
 
@@ -92,13 +92,16 @@ One JSON per note (rather than an aggregate log) makes the corpus trivially inge
 ```
 .
 ├── README.md                       (this file)
+├── .githooks/
+│   └── post-rewrite                git hook: rebase/amend → rewrite notes
 ├── skills/
-│   └── why-notes/                  the skill (record + consult)
+│   └── why-notes/                  the skill (record + consult + rewrite)
 │       ├── SKILL.md                trigger guidance for agents
 │       └── src/
 │           ├── note.py             Note + NotesStore classes (shared)
 │           ├── record.py           recorder CLI
-│           └── consult.py          lookup CLI
+│           ├── consult.py          lookup CLI
+│           └── rewrite.py          rebase/amend patcher CLI
 └── why-notes/                      the recorded corpus
     └── <repo>/<dir>/<basename>-<uuid>.json
 ```

--- a/skills/why-notes/SKILL.md
+++ b/skills/why-notes/SKILL.md
@@ -25,6 +25,14 @@ Pass `--related` UUIDs (look them up via `consult.py`) when this decision builds
 
 Run either script with `--help` for the full contract.
 
+**Rebase / amend** appends the new short SHA to each affected note's `commit` chain (newest last) and recomputes the checksum, so notes keep pointing at live history. Enable once per repo:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The bundled `.githooks/post-rewrite` invokes `src/rewrite.py --stdin`. For one-off fixes, run it directly with `--map OLD=NEW`.
+
 Three rules the script can't enforce:
 
 - **One decision per note.** Keep each note minimal and focused on a single architectural decision. Splitting one discussion into several notes is encouraged.

--- a/skills/why-notes/src/consult.py
+++ b/skills/why-notes/src/consult.py
@@ -22,7 +22,11 @@ def print_note(n, label, show_location=False):
     print(f"timestamp: {n.timestamp or '?'}")
     print(f"agent:     {n.agent or '?'}")
     print(f"model:     {n.model or '?'}")
-    print(f"commit:    {n.commit or '?'}")
+    chain = n.commit if isinstance(n.commit, list) else ([n.commit] if n.commit else [])
+    if len(chain) > 1:
+        print(f"commit:    {chain[-1]}  (rewritten {len(chain) - 1}x; original {chain[0]})")
+    else:
+        print(f"commit:    {n.current_commit() or '?'}")
     print(f"branch:    {n.branch or '?'}")
     print(f"related:   {', '.join(related) if related else '(none)'}")
     print()

--- a/skills/why-notes/src/note.py
+++ b/skills/why-notes/src/note.py
@@ -16,7 +16,7 @@ from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 
 
-SCHEMA_VERSION = "2.0.0"
+SCHEMA_VERSION = "3.0.0"
 
 # Canonical fields hashed into the checksum for newly-created notes. Each note
 # stores its own `checksum_fields` list, so this constant only seeds new notes;
@@ -64,7 +64,11 @@ class Note:
     dir: str
     basename: str
     branch: str
-    commit: str
+    # `list[str]` from v3.0.0 onward: index 0 is the original anchor, the
+    # last element is current, middle entries are intermediate rewrites
+    # (rebase / amend). Legacy v2 notes stored a single string; from_dict
+    # preserves whichever form is on disk so existing checksums verify.
+    commit: list[str] | str
     note: str
     version: str = ""
     repo_url: str = ""
@@ -88,7 +92,7 @@ class Note:
             dir=dir_in_repo,
             basename=file_rel.name,
             branch=branch,
-            commit=commit,
+            commit=[commit],
             related=list(related or []),
             note=note,
             checksum_fields=list(CHECKSUM_FIELDS),
@@ -166,6 +170,31 @@ class Note:
     def location(self):
         d = self.dir or ""
         return f"{self.repo}/" + (f"{d}/" if d else "") + self.basename
+
+    def current_commit(self) -> str:
+        """The currently-active short SHA, regardless of on-disk form."""
+        if isinstance(self.commit, list):
+            return self.commit[-1] if self.commit else ""
+        return self.commit
+
+    def append_commit(self, new_sha: str) -> bool:
+        """Record a rewrite of the current commit (rebase / amend).
+
+        Promotes legacy string-form `commit` to a list, appends the new
+        SHA, bumps `version` to the current schema, and recomputes the
+        checksum. No-ops if `new_sha` already equals the current commit
+        (idempotent against re-runs of the rewrite hook). Returns True
+        if the note changed.
+        """
+        if not new_sha or new_sha == self.current_commit():
+            return False
+        if isinstance(self.commit, str):
+            self.commit = [self.commit, new_sha] if self.commit else [new_sha]
+        else:
+            self.commit = [*self.commit, new_sha]
+        self.version = SCHEMA_VERSION
+        self.checksum = self.compute_checksum()
+        return True
 
 
 class NotesStore:

--- a/skills/why-notes/src/rewrite.py
+++ b/skills/why-notes/src/rewrite.py
@@ -1,0 +1,137 @@
+"""rewrite: update why-notes after a git rebase or amend.
+
+Designed to be invoked by git's `post-rewrite` hook, which feeds
+`<old-sha> <new-sha>` pairs on stdin for every rewritten commit. For
+each matching note in the local corpus, appends the new short SHA to
+`commit` and recomputes the checksum.
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from note import (
+    NotesStore,
+    git,
+    reconfigure_streams_utf8,
+)
+
+
+def short_sha(full_sha: str, cwd) -> str:
+    """Abbreviate a full SHA the same way record.py captures it."""
+    out = git("rev-parse", "--short", full_sha, cwd=cwd)
+    return out or full_sha
+
+
+def parse_pairs(lines):
+    """Yield (old, new) tuples from `<old> <new>` lines. Skips blanks/garbage."""
+    for raw in lines:
+        parts = raw.strip().split()
+        if len(parts) >= 2:
+            yield parts[0], parts[1]
+
+
+def apply_rewrites(store: NotesStore, pairs, cwd) -> tuple[int, int]:
+    """Walk the corpus and append new SHAs to any note matching an old SHA.
+
+    Matches the note's current short commit against the full old SHA by
+    prefix, since the corpus stores short SHAs but git's post-rewrite
+    emits full ones. Returns (notes_updated, pairs_matched).
+    """
+    # Pre-abbreviate the new SHAs once, and remember which pairs ever matched.
+    resolved = [(old, short_sha(new, cwd=cwd)) for old, new in pairs]
+    matched_pairs = set()
+    updated = 0
+    for path, note in store.iter_notes():
+        cur = note.current_commit()
+        if not cur:
+            continue
+        new_short = None
+        for old, new_s in resolved:
+            if old.startswith(cur):
+                new_short = new_s
+                matched_pairs.add((old, new_s))
+                break
+        if new_short is None:
+            continue
+        if note.append_commit(new_short):
+            path.write_text(
+                json.dumps(note.to_dict(), indent=2, ensure_ascii=False) + "\n",
+                encoding="utf-8",
+            )
+            updated += 1
+    return updated, len(matched_pairs)
+
+
+def main():
+    reconfigure_streams_utf8((sys.stdin, sys.stdout, sys.stderr))
+
+    parser = argparse.ArgumentParser(
+        prog="rewrite",
+        description=(
+            "Patch why-notes after a git rebase or amend so their `commit` "
+            "anchors stay pointed at live history. Designed for git's "
+            "post-rewrite hook, which feeds `<old-sha> <new-sha>` pairs on "
+            "stdin. Each matching note gets the new short SHA appended to "
+            "its commit chain and its checksum recomputed."
+        ),
+        epilog=(
+            "Corpus lookup follows the same rule as record/consult: "
+            "$WHY_NOTES_DIR if set, else <git-repo-root>/why-notes/, else "
+            "<cwd>/why-notes/. Notes are matched by short-SHA prefix; "
+            "pairs that don't match any note are silently skipped."
+        ),
+    )
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument(
+        "--stdin", action="store_true",
+        help="Read `<old-sha> <new-sha>` pairs from stdin, one per line "
+             "(the format git's post-rewrite hook emits).",
+    )
+    src.add_argument(
+        "--map", action="append", default=[], metavar="OLD=NEW",
+        help="One-off rewrite pair, e.g. `--map abc123=def456`. Repeatable.",
+    )
+    parser.add_argument(
+        "--quiet", action="store_true",
+        help="Suppress the summary line on stderr.",
+    )
+    args = parser.parse_args()
+
+    if args.stdin:
+        pairs = list(parse_pairs(sys.stdin))
+    else:
+        pairs = []
+        for entry in args.map:
+            if "=" not in entry:
+                print(f"rewrite: bad --map value {entry!r} (expected OLD=NEW)", file=sys.stderr)
+                return 2
+            old, new = entry.split("=", 1)
+            pairs.append((old.strip(), new.strip()))
+
+    if not pairs:
+        if not args.quiet:
+            print("rewrite: no rewrite pairs received; nothing to do", file=sys.stderr)
+        return 0
+
+    cwd = Path(os.getcwd())
+    store = NotesStore.resolve(cwd)
+    if not store.root.is_dir():
+        if not args.quiet:
+            print(f"rewrite: no notes directory at {store.root}", file=sys.stderr)
+        return 0
+
+    updated, matched = apply_rewrites(store, pairs, cwd=cwd)
+    if not args.quiet:
+        print(
+            f"rewrite: updated {updated} note(s) across {matched} matched "
+            f"pair(s) of {len(pairs)} received",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,6 +16,8 @@ ROOT = Path(__file__).resolve().parent.parent
 SRC = ROOT / "skills" / "why-notes" / "src"
 RECORD = SRC / "record.py"
 CONSULT = SRC / "consult.py"
+REWRITE = SRC / "rewrite.py"
+HOOK = ROOT / ".githooks" / "post-rewrite"
 
 
 def init_git_repo(path):
@@ -53,6 +55,18 @@ def run_consult(cwd, notes_dir, *args):
     return subprocess.run(
         [sys.executable, str(CONSULT), *args],
         cwd=cwd,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def run_rewrite(cwd, notes_dir, *args, stdin=""):
+    env = {**os.environ, "WHY_NOTES_DIR": str(notes_dir)}
+    return subprocess.run(
+        [sys.executable, str(REWRITE), *args],
+        cwd=cwd,
+        input=stdin,
         capture_output=True,
         text=True,
         env=env,
@@ -285,6 +299,191 @@ class ConsultCliTests(unittest.TestCase):
             self.repo, self.notes, "--repo", "../escape", "--file", "src/foo.py"
         )
         self.assertEqual(c.returncode, 2)
+
+
+class RewriteCliTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.repo = Path(self.tmp.name) / "repo"
+        self.repo.mkdir()
+        self.notes = Path(self.tmp.name) / "notes"
+        init_git_repo(self.repo)
+
+    def _record_one(self):
+        r = run_record(
+            self.repo, self.notes,
+            "--agent", "claude", "--model", "opus 4.7",
+            "--repo", "demo", "--file", "src/foo.py",
+            stdin="original rationale",
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        path = next((self.notes / "demo" / "src").glob("foo.py-*.json"))
+        return path, json.loads(path.read_text(encoding="utf-8"))
+
+    def test_map_appends_new_sha_and_recomputes_checksum(self):
+        path, before = self._record_one()
+        old_short = before["commit"][0] if isinstance(before["commit"], list) else before["commit"]
+        # Make a second commit so we have a distinct SHA to rewrite TO; without
+        # it `new_full` would still resolve to the note's anchor and
+        # append_commit (idempotent) would correctly no-op.
+        (self.repo / "second.txt").write_text("x\n", encoding="utf-8")
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "test@example.com",
+        }
+        subprocess.run(["git", "add", "second.txt"], cwd=self.repo, check=True, env=env)
+        subprocess.run(["git", "commit", "-q", "-m", "second"], cwd=self.repo, check=True, env=env)
+        new_full = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=self.repo,
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+        r = run_rewrite(
+            self.repo, self.notes,
+            "--map", f"{old_short}={new_full}",
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        after = json.loads(path.read_text(encoding="utf-8"))
+        self.assertIsInstance(after["commit"], list)
+        self.assertEqual(after["commit"][0], old_short)
+        self.assertEqual(len(after["commit"]), 2)
+        self.assertNotEqual(after["checksum"], before["checksum"])
+
+        # Re-verifies via consult.
+        c = run_consult(self.repo, self.notes, "--repo", "demo", "--file", "src/foo.py")
+        self.assertEqual(c.returncode, 0, c.stderr)
+        self.assertNotIn("failed checksum", c.stderr)
+
+    def test_stdin_skips_pairs_with_no_matching_note(self):
+        path, before = self._record_one()
+        r = run_rewrite(
+            self.repo, self.notes,
+            "--stdin",
+            stdin="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
+                  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n",
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        after = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(after["commit"], before["commit"])
+        self.assertEqual(after["checksum"], before["checksum"])
+
+    def test_stdin_handles_empty_input(self):
+        r = run_rewrite(self.repo, self.notes, "--stdin", stdin="")
+        self.assertEqual(r.returncode, 0, r.stderr)
+
+    def test_idempotent_against_repeat_invocations(self):
+        path, _ = self._record_one()
+        (self.repo / "second.txt").write_text("x\n", encoding="utf-8")
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "test@example.com",
+        }
+        subprocess.run(["git", "add", "second.txt"], cwd=self.repo, check=True, env=env)
+        subprocess.run(["git", "commit", "-q", "-m", "second"], cwd=self.repo, check=True, env=env)
+        new_full = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=self.repo,
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        old_short = json.loads(path.read_text(encoding="utf-8"))["commit"]
+        if isinstance(old_short, list):
+            old_short = old_short[0]
+        run_rewrite(self.repo, self.notes, "--map", f"{old_short}={new_full}")
+        after_first = json.loads(path.read_text(encoding="utf-8"))
+
+        # Second invocation with the same pair: current SHA already equals
+        # the abbreviated new SHA, so append_commit no-ops.
+        new_short = after_first["commit"][-1]
+        run_rewrite(self.repo, self.notes, "--map", f"{new_short}={new_full}")
+        after_second = json.loads(path.read_text(encoding="utf-8"))
+        self.assertEqual(after_first, after_second)
+
+
+class BundledHookTests(unittest.TestCase):
+    def test_bundled_hook_is_executable_and_invokes_rewrite(self):
+        self.assertTrue(HOOK.is_file(), f"bundled hook missing: {HOOK}")
+        self.assertTrue(os.access(HOOK, os.X_OK), f"bundled hook not executable: {HOOK}")
+        body = HOOK.read_text(encoding="utf-8")
+        # Must end with executing rewrite.py from the repo's installed skill.
+        self.assertIn("skills/why-notes/src/rewrite.py", body)
+        self.assertIn("--stdin", body)
+
+
+class PostRewriteHookTests(unittest.TestCase):
+    """End-to-end: a real rebase fires .githooks/post-rewrite, which
+    pipes git's mapping into rewrite.py and patches matching notes."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.repo = Path(self.tmp.name) / "repo"
+        self.repo.mkdir()
+        self.notes = Path(self.tmp.name) / "notes"
+
+        # A repo with 3 commits we can rebase. Hook is wired via
+        # core.hooksPath to the bundled .githooks dir from this checkout.
+        self.git_env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "test", "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "test", "GIT_COMMITTER_EMAIL": "test@example.com",
+            "WHY_NOTES_DIR": str(self.notes),
+            "GIT_SEQUENCE_EDITOR": "true",  # accept the rebase todo as-is
+        }
+        subprocess.run(["git", "init", "-q", "-b", "main"], cwd=self.repo, check=True, env=self.git_env)
+        # Bundled hook resolves `$REPO_ROOT/skills/why-notes/src/rewrite.py`,
+        # which only exists when the user's repo has the skill installed
+        # alongside the notes (the why-notes repo's own setup). The temp repo
+        # doesn't, so write a test-only hook that invokes rewrite.py from this
+        # checkout's source tree directly.
+        hooks_dir = Path(self.tmp.name) / "hooks"
+        hooks_dir.mkdir()
+        hook = hooks_dir / "post-rewrite"
+        hook.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            f"exec {sys.executable} {REWRITE} --stdin\n",
+            encoding="utf-8",
+        )
+        hook.chmod(0o755)
+        subprocess.run(["git", "config", "core.hooksPath", str(hooks_dir)],
+                       cwd=self.repo, check=True, env=self.git_env)
+        for i in range(3):
+            f = self.repo / f"f{i}.txt"
+            f.write_text(f"{i}\n", encoding="utf-8")
+            subprocess.run(["git", "add", f.name], cwd=self.repo, check=True, env=self.git_env)
+            subprocess.run(["git", "commit", "-q", "-m", f"c{i}"], cwd=self.repo,
+                           check=True, env=self.git_env)
+
+    def test_amend_propagates_to_note(self):
+        r = run_record(
+            self.repo, self.notes,
+            "--agent", "claude", "--model", "opus 4.7",
+            "--repo", "demo", "--file", "src/foo.py",
+            stdin="anchor",
+        )
+        self.assertEqual(r.returncode, 0, r.stderr)
+        path = next((self.notes / "demo" / "src").glob("foo.py-*.json"))
+        before = json.loads(path.read_text(encoding="utf-8"))
+        old_short = before["commit"][0] if isinstance(before["commit"], list) else before["commit"]
+
+        # Amend HEAD with a new message to guarantee a different SHA
+        # (--no-edit + same-second timestamp can otherwise reproduce the
+        # original SHA and the post-rewrite pair becomes an identity).
+        subprocess.run(
+            ["git", "commit", "--amend", "-q", "-m", "c2-reworded"],
+            cwd=self.repo, check=True, env=self.git_env,
+        )
+        after = json.loads(path.read_text(encoding="utf-8"))
+        self.assertIsInstance(after["commit"], list)
+        self.assertEqual(after["commit"][0], old_short)
+        self.assertEqual(len(after["commit"]), 2)
+
+        # And the note still verifies via consult.
+        c = run_consult(self.repo, self.notes, "--repo", "demo", "--file", "src/foo.py")
+        self.assertEqual(c.returncode, 0, c.stderr)
+        self.assertNotIn("failed checksum", c.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -30,7 +30,7 @@ def make_note(**overrides):
         repo_url="https://example.com/repo",
         file_rel=PurePosixPath("src/note.py"),
         branch="main",
-        commit="abc1234",
+        commit="abc1234",  # caller-facing arg; Note.create wraps it in a list
         related=[],
         note="some rationale",
     )
@@ -133,6 +133,93 @@ class NoteChecksumTests(unittest.TestCase):
         self.assertIn("checksum_fields", CHECKSUM_FIELDS)
         # Used by new notes, so SCHEMA_VERSION must be a non-empty string.
         self.assertTrue(SCHEMA_VERSION)
+
+
+class CommitChainTests(unittest.TestCase):
+    def test_new_note_stores_commit_as_single_element_list(self):
+        n = make_note(commit="abc1234")
+        self.assertEqual(n.commit, ["abc1234"])
+        self.assertEqual(n.current_commit(), "abc1234")
+        self.assertEqual(n.verify(), "valid")
+
+    def test_append_commit_extends_chain_and_recomputes_checksum(self):
+        n = make_note(commit="abc1234")
+        original = n.checksum
+        self.assertTrue(n.append_commit("def5678"))
+        self.assertEqual(n.commit, ["abc1234", "def5678"])
+        self.assertEqual(n.current_commit(), "def5678")
+        self.assertNotEqual(n.checksum, original)
+        self.assertEqual(n.verify(), "valid")
+
+    def test_append_commit_is_idempotent_on_current(self):
+        n = make_note(commit="abc1234")
+        self.assertFalse(n.append_commit("abc1234"))
+        self.assertEqual(n.commit, ["abc1234"])
+
+    def test_append_commit_ignores_empty_new_sha(self):
+        n = make_note(commit="abc1234")
+        self.assertFalse(n.append_commit(""))
+        self.assertEqual(n.commit, ["abc1234"])
+
+    def test_legacy_string_commit_verifies_against_string_checksum(self):
+        # Build a v2-shaped on-disk record with a string commit field, then
+        # verify the loaded note still hashes against the string form.
+        legacy = {
+            "timestamp": "2026-01-01T00:00:00+00:00",
+            "uuid": "11111111-1111-1111-1111-111111111111",
+            "version": "2.0.0",
+            "agent": "claude",
+            "model": "opus 4.6",
+            "repo": "why-notes",
+            "dir": "src",
+            "basename": "note.py",
+            "branch": "main",
+            "commit": "deadbee",
+            "related": [],
+            "note": "legacy rationale",
+            "checksum_fields": list(CHECKSUM_FIELDS),
+        }
+        # Compute what the on-disk checksum would have been for this v2 note.
+        n = Note.from_dict(legacy)
+        legacy["checksum"] = n.compute_checksum()
+        n = Note.from_dict(legacy)
+        self.assertEqual(n.commit, "deadbee")  # string form preserved
+        self.assertEqual(n.verify(), "valid")
+
+    def test_append_commit_migrates_legacy_string_to_list(self):
+        # Same v2 fixture; after a rewrite, commit becomes a list and the
+        # note's version bumps to current SCHEMA_VERSION.
+        legacy = {
+            "timestamp": "2026-01-01T00:00:00+00:00",
+            "uuid": "22222222-2222-2222-2222-222222222222",
+            "version": "2.0.0",
+            "agent": "claude",
+            "model": "opus 4.6",
+            "repo": "why-notes",
+            "dir": "src",
+            "basename": "note.py",
+            "branch": "main",
+            "commit": "deadbee",
+            "related": [],
+            "note": "legacy rationale",
+            "checksum_fields": list(CHECKSUM_FIELDS),
+        }
+        n = Note.from_dict(legacy)
+        legacy["checksum"] = n.compute_checksum()
+        n = Note.from_dict(legacy)
+
+        self.assertTrue(n.append_commit("cafebab"))
+        self.assertEqual(n.commit, ["deadbee", "cafebab"])
+        self.assertEqual(n.version, SCHEMA_VERSION)
+        self.assertEqual(n.verify(), "valid")
+
+    def test_multi_step_rewrite_chain(self):
+        n = make_note(commit="aaaaaaa")
+        n.append_commit("bbbbbbb")
+        n.append_commit("ccccccc")
+        self.assertEqual(n.commit, ["aaaaaaa", "bbbbbbb", "ccccccc"])
+        self.assertEqual(n.current_commit(), "ccccccc")
+        self.assertEqual(n.verify(), "valid")
 
 
 class NoteSerializationTests(unittest.TestCase):

--- a/why-notes/why-notes/.githooks/post-rewrite-4e9a71a1-ef59-4b4f-8005-4e3f47b5c00d.json
+++ b/why-notes/why-notes/.githooks/post-rewrite-4e9a71a1-ef59-4b4f-8005-4e3f47b5c00d.json
@@ -1,0 +1,30 @@
+{
+  "timestamp": "2026-05-13T17:06:35.587799+00:00",
+  "uuid": "4e9a71a1-ef59-4b4f-8005-4e3f47b5c00d",
+  "version": "3.0.0",
+  "agent": "claude",
+  "model": "opus 4.7",
+  "repo": "why-notes",
+  "repo_url": "git@github.com:JooseRajamaeki/why-notes.git",
+  "dir": ".githooks",
+  "basename": "post-rewrite",
+  "branch": "feature/rebase-aware-commits",
+  "commit": [
+    "864d5c1"
+  ],
+  "related": [],
+  "note": "The bundled post-rewrite hook resolves the rewrite script via\n`$REPO_ROOT/skills/why-notes/src/rewrite.py` — that is, it assumes the\nconsuming repo has the skill installed at exactly that path. This\nholds for the why-notes repo itself and for any repo where users\nvendor the skill in alongside their notes corpus (the documented\ninstallation pattern). It does NOT work if the skill lives elsewhere\non the system; users in that situation must either symlink the skill\ninto the repo, configure `core.hooksPath` to a different hook script,\nor invoke `rewrite.py --stdin` from a custom hook.\n\nThe test suite cannot exercise the bundled hook verbatim because the\ntemp git repos created in `PostRewriteHookTests.setUp` don't carry the\nskill files. Tests use a separate `tests`-only hook that exec's the\nreal `rewrite.py` from the source tree directly. A separate test\n(`BundledHookTests`) covers the bundled script's executability and\nshape so the install-time assumption stays documented.",
+  "checksum_fields": [
+    "agent",
+    "basename",
+    "checksum_fields",
+    "commit",
+    "dir",
+    "model",
+    "note",
+    "timestamp",
+    "uuid",
+    "version"
+  ],
+  "checksum": "c771937ebd57890c661fc82fed64aac546f45efe48b4c3231233d7c17ef1ea48"
+}


### PR DESCRIPTION
## Summary
- `commit` becomes `list[str]` — oldest first, last entry current. Rebases/amends append the new short SHA to each affected note's chain and recompute the checksum, so notes keep pointing at live history.
- New `src/rewrite.py` reads `<old> <new>` pairs (stdin or `--map`). Bundled `.githooks/post-rewrite` invokes it after every rebase/amend; enable per-repo with `git config core.hooksPath .githooks`.
- Schema bumps to **3.0.0**. Legacy v2 notes verify against their original string-form checksum as-is; migration to list form happens lazily on the first rewrite.
- Out of scope (deliberately split): dropped-commit detection on consult — to be addressed in a follow-up PR.

## Test plan
- [x] `python3 -m unittest discover -s tests` — 61 tests pass
- [x] Unit tests cover the new commit-chain semantics: single-element list on create, append + checksum recompute, idempotency on equal SHA, legacy string→list lazy migration, multi-step chain.
- [x] CLI tests for `rewrite.py --map` and `rewrite.py --stdin`, including unmatched-pair no-op and idempotency across repeat invocations.
- [x] End-to-end `PostRewriteHookTests` exercises a real `git commit --amend` firing a hook that pipes git's mapping into `rewrite.py`.
- [x] `BundledHookTests` asserts the shipped hook is executable and invokes `rewrite.py --stdin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)